### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ You can also use other custom data sources, as long as the data source format is
 
 ## Star History
 
-<a href="https://star-history.com/#syt2/zotero-addons&Timeline">
+<a href="https://star-history.dera.page/#syt2/zotero-addons&Timeline">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=syt2/zotero-addons&type=Timeline&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=syt2/zotero-addons&type=Timeline" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=syt2/zotero-addons&type=Timeline" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=syt2/zotero-addons&type=Timeline&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=syt2/zotero-addons&type=Timeline" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=syt2/zotero-addons&type=Timeline" />
   </picture>
 </a>

--- a/doc/README-CN.md
+++ b/doc/README-CN.md
@@ -50,10 +50,10 @@
 
 ## Star 历史
 
-<a href="https://star-history.com/#syt2/zotero-addons&Timeline">
+<a href="https://star-history.dera.page/#syt2/zotero-addons&Timeline">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=syt2/zotero-addons&type=Timeline&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=syt2/zotero-addons&type=Timeline" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=syt2/zotero-addons&type=Timeline" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=syt2/zotero-addons&type=Timeline&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=syt2/zotero-addons&type=Timeline" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=syt2/zotero-addons&type=Timeline" />
   </picture>
 </a>


### PR DESCRIPTION
The star history chart on the README no longer renders because the underlying GitHub stargazer API is restricted. This update points the chart to a working replacement in both the English and Chinese READMEs so the image displays correctly again.