### PR TITLE
fix: address Zotero 10 add-on window regressions

### DIFF
--- a/src/modules/addonDetail.ts
+++ b/src/modules/addonDetail.ts
@@ -14,7 +14,7 @@ import { HistoricalVersions } from "./historicalVersions";
 import { getString } from "../utils/locale";
 import { installAddonFrom, undoUninstall, uninstall } from "../services";
 import { config } from "../../package.json";
-import { isWindowAlive } from "../utils/window";
+import { getActiveWindow, isWindowAlive } from "../utils/window";
 import { getXPIDatabase, getAddonManager } from "../utils/compat";
 import { DetailButtonHandler } from "../ui/detail";
 
@@ -504,6 +504,7 @@ export class AddonInfoDetail {
 
   private static showRollbackError(text: string) {
     new ztoolkit.ProgressWindow(getString("addon-name"), {
+      window: getActiveWindow(),
       closeOnClick: true,
       closeTime: 3000,
     })

--- a/src/modules/addonTable.ts
+++ b/src/modules/addonTable.ts
@@ -9,7 +9,7 @@ import {
   addonReleaseInfo,
   relatedAddons,
 } from "./addonInfo";
-import { isWindowAlive } from "../utils/window";
+import { getActiveWindow, isWindowAlive } from "../utils/window";
 import {
   Sources,
   currentSource,
@@ -328,6 +328,7 @@ export class AddonTable {
       return;
     }
     const progressWin = new ztoolkit.ProgressWindow(getString("addon-name"), {
+      window: getActiveWindow(),
       closeOnClick: true,
       closeTime: -1,
     })

--- a/src/modules/addonTable.ts
+++ b/src/modules/addonTable.ts
@@ -167,14 +167,16 @@ export class AddonTable {
   /**
    * Display addon table window
    */
-  static async showAddonsWindow(options?: { from?: "toolbar" | "menu" }) {
+  static async showAddonsWindow(options?: {
+    from?: "toolbar" | "menu";
+  }): Promise<Window | undefined> {
     if (this.window && isWindowAlive(this.window)) {
       if (options?.from) {
         this.updateHideToolbarEntranceInWindow(options.from === "toolbar");
       }
       this.window.focus();
       this.refresh();
-      return;
+      return this.window;
     }
     this.resetWindowTransientState();
     let resolveInit: () => void;
@@ -246,6 +248,7 @@ export class AddonTable {
       }
       Guide.showGuideInAddonTableIfNeed(this.window);
     }, 2000);
+    return win;
   }
 
   /**

--- a/src/modules/registerScheme.ts
+++ b/src/modules/registerScheme.ts
@@ -1,4 +1,5 @@
 import { getString } from "../utils/locale";
+import { resolveProgressWindowOwner } from "../utils/window";
 import { AddonTable } from "../modules/addonTable";
 import { AddonInfoManager } from "../modules/addonInfo";
 import {
@@ -111,9 +112,10 @@ async function handleConfigSource(params: any): Promise<void> {
   }
 
   if (success) {
-    AddonTable.close();
-    AddonTable.showAddonsWindow();
+    await AddonTable.close();
+    const addonTableWindow = await AddonTable.showAddonsWindow();
     new ztoolkit.ProgressWindow(getString("addon-name"), {
+      window: resolveProgressWindowOwner(addonTableWindow),
       closeOnClick: true,
       closeTime: 3000,
     })

--- a/src/services/AddonInstallService.ts
+++ b/src/services/AddonInstallService.ts
@@ -7,6 +7,7 @@ import { ProgressWindowHelper } from "zotero-plugin-toolkit";
 import { config } from "../../package.json";
 import { getString } from "../utils/locale";
 import { getAddonManager } from "../utils/compat";
+import { getActiveWindow, isWindowAlive } from "../utils/window";
 import type {
   AddonInfo,
   LocalAddon,
@@ -21,6 +22,8 @@ export interface InstallOptions {
   name?: string;
   popWin?: boolean;
   startIndex?: number;
+  /** Owner for dependent progress windows. */
+  window?: Window;
 }
 
 /**
@@ -29,6 +32,8 @@ export interface InstallOptions {
 export interface UninstallOptions {
   popConfirmDialog?: boolean;
   canRestore?: boolean;
+  /** Owner for dependent progress windows. */
+  window?: Window;
 }
 
 /**
@@ -85,6 +90,9 @@ export async function uninstall(
   addon: LocalAddon,
   options?: UninstallOptions,
 ): Promise<boolean> {
+  const progressWindowOwner = isWindowAlive(options?.window)
+    ? options.window
+    : getActiveWindow();
   if (options?.popConfirmDialog) {
     const confirm = await (Services as any).prompt.confirmEx(
       null as any,
@@ -106,6 +114,7 @@ export async function uninstall(
   }
 
   const popWin = new ztoolkit.ProgressWindow(getString("addon-name"), {
+    window: progressWindowOwner,
     closeOnClick: true,
     closeTime: 3000,
   });
@@ -145,6 +154,9 @@ export async function installAddonFrom(
   url: string | string[],
   options?: InstallOptions,
 ): Promise<void> {
+  const progressWindowOwner = isWindowAlive(options?.window)
+    ? options.window
+    : getActiveWindow();
   if (!Array.isArray(url)) {
     url = [url];
   }
@@ -168,6 +180,7 @@ export async function installAddonFrom(
   let popWin: ProgressWindowHelper | undefined = undefined;
   if (options?.popWin) {
     popWin = new ztoolkit.ProgressWindow(getString("addon-name"), {
+      window: progressWindowOwner,
       closeOnClick: true,
       closeTime: -1,
     })
@@ -292,8 +305,11 @@ export async function installAddonFrom(
   const doNextUrlInstall = await actualInstall();
   popWin?.startCloseTimer(2000);
   if (doNextUrlInstall && Array.isArray(url) && url.length > 1) {
-    options = options ?? {};
-    options.startIndex = startIndex + 1;
+    options = {
+      ...options,
+      startIndex: startIndex + 1,
+      window: progressWindowOwner,
+    };
     return await installAddonFrom(url, options);
   }
 }

--- a/src/services/AddonInstallService.ts
+++ b/src/services/AddonInstallService.ts
@@ -7,7 +7,7 @@ import { ProgressWindowHelper } from "zotero-plugin-toolkit";
 import { config } from "../../package.json";
 import { getString } from "../utils/locale";
 import { getAddonManager } from "../utils/compat";
-import { getActiveWindow, isWindowAlive } from "../utils/window";
+import { resolveProgressWindowOwner } from "../utils/window";
 import type {
   AddonInfo,
   LocalAddon,
@@ -90,9 +90,7 @@ export async function uninstall(
   addon: LocalAddon,
   options?: UninstallOptions,
 ): Promise<boolean> {
-  const progressWindowOwner = isWindowAlive(options?.window)
-    ? options.window
-    : getActiveWindow();
+  const progressWindowOwner = resolveProgressWindowOwner(options?.window);
   if (options?.popConfirmDialog) {
     const confirm = await (Services as any).prompt.confirmEx(
       null as any,
@@ -154,9 +152,7 @@ export async function installAddonFrom(
   url: string | string[],
   options?: InstallOptions,
 ): Promise<void> {
-  const progressWindowOwner = isWindowAlive(options?.window)
-    ? options.window
-    : getActiveWindow();
+  const progressWindowOwner = resolveProgressWindowOwner(options?.window);
   if (!Array.isArray(url)) {
     url = [url];
   }

--- a/src/ui/table/TableColumnManager.ts
+++ b/src/ui/table/TableColumnManager.ts
@@ -15,9 +15,13 @@ type PersistedColumnState = Pick<
 >;
 
 const TAG_COLUMN_MIGRATION_PREF = "tagColumnLayoutMigrated";
+const NAME_COLUMN_MIGRATION_PREF = "nameColumnWidthMigrated";
+const NAME_COLUMN_KEY = "menu-name";
 const TAG_COLUMN_KEY = "menu-tags";
 const STAR_COLUMN_KEY = "menu-star";
 const TAG_COLUMN_WIDTH = 96;
+const NAME_COLUMN_WIDTH = 200;
+const NAME_COLUMN_MIN_WIDTH = 160;
 
 export class TableColumnManager {
   private largePrefHelper = new LargePrefHelper(
@@ -56,6 +60,7 @@ export class TableColumnManager {
       // Use default columns
     }
     this.migrateTagColumnLayoutIfNeeded();
+    this.migrateNameColumnWidthIfNeeded();
     this._columns.map((column) =>
       // @ts-expect-error ignore getString type check
       Object.assign(column, { label: getString(column.dataKey) }),
@@ -120,9 +125,11 @@ export class TableColumnManager {
   private getDefaultColumns(): ExtendedColumnOptions[] {
     return [
       {
-        dataKey: "menu-name",
+        dataKey: NAME_COLUMN_KEY,
         label: "menu-name",
         staticWidth: true,
+        width: NAME_COLUMN_WIDTH,
+        minWidth: NAME_COLUMN_MIN_WIDTH,
         hidden: false,
         ordinal: 0,
       },
@@ -232,6 +239,39 @@ export class TableColumnManager {
       this._columns.map((column) => this.toPersistedColumnState(column)),
     );
     setPref(TAG_COLUMN_MIGRATION_PREF, true);
+  }
+
+  /**
+   * Repair the missing name-column width used by older releases.
+   *
+   * Zotero 7 distributed width across columns that omitted it. Zotero 10's
+   * virtualized table treats a static column without a width as effectively
+   * minimum-sized, so existing persisted layouts can make the name column
+   * nearly unreadable.
+   */
+  private migrateNameColumnWidthIfNeeded(): void {
+    if (getPref(NAME_COLUMN_MIGRATION_PREF)) {
+      return;
+    }
+
+    const nameColumn = this._columns.find(
+      (column) => column.dataKey === NAME_COLUMN_KEY,
+    );
+    if (!nameColumn) {
+      return;
+    }
+
+    const width = Number(nameColumn.width);
+    if (!Number.isFinite(width) || width < NAME_COLUMN_MIN_WIDTH) {
+      nameColumn.width = NAME_COLUMN_WIDTH;
+    }
+    nameColumn.minWidth = NAME_COLUMN_MIN_WIDTH;
+
+    this.largePrefHelper.setValue(
+      "columns",
+      this._columns.map((column) => this.toPersistedColumnState(column)),
+    );
+    setPref(NAME_COLUMN_MIGRATION_PREF, true);
   }
 
   /**

--- a/src/ui/table/TableColumnManager.ts
+++ b/src/ui/table/TableColumnManager.ts
@@ -16,6 +16,20 @@ type PersistedColumnState = Pick<
 
 const TAG_COLUMN_MIGRATION_PREF = "tagColumnLayoutMigrated";
 const NAME_COLUMN_MIGRATION_PREF = "nameColumnWidthMigrated";
+
+type MigrationPrefKey =
+  | typeof TAG_COLUMN_MIGRATION_PREF
+  | typeof NAME_COLUMN_MIGRATION_PREF;
+
+type ColumnPreferenceStore = Pick<LargePrefHelper, "getValue" | "setValue">;
+
+export interface TableColumnManagerDependencies {
+  columnPreferenceStore?: ColumnPreferenceStore;
+  getMigrationPref?: (key: MigrationPrefKey) => boolean | undefined;
+  setMigrationPref?: (key: MigrationPrefKey, value: boolean) => void;
+  getColumnLabel?: (key: string) => string;
+}
+
 const NAME_COLUMN_KEY = "menu-name";
 const TAG_COLUMN_KEY = "menu-tags";
 const STAR_COLUMN_KEY = "menu-star";
@@ -24,12 +38,29 @@ const NAME_COLUMN_WIDTH = 200;
 const NAME_COLUMN_MIN_WIDTH = 160;
 
 export class TableColumnManager {
-  private largePrefHelper = new LargePrefHelper(
-    "zotero.addons.ui",
-    config.prefsPrefix,
-    "parser",
-  );
+  private columnPreferenceStore: ColumnPreferenceStore;
+  private getMigrationPref: NonNullable<
+    TableColumnManagerDependencies["getMigrationPref"]
+  >;
+  private setMigrationPref: NonNullable<
+    TableColumnManagerDependencies["setMigrationPref"]
+  >;
+  private getColumnLabel: NonNullable<
+    TableColumnManagerDependencies["getColumnLabel"]
+  >;
   private _columns: ExtendedColumnOptions[] = [];
+
+  constructor(dependencies: TableColumnManagerDependencies = {}) {
+    this.columnPreferenceStore =
+      dependencies.columnPreferenceStore ??
+      new LargePrefHelper("zotero.addons.ui", config.prefsPrefix, "parser");
+    this.getMigrationPref =
+      dependencies.getMigrationPref ?? ((key) => getPref(key));
+    this.setMigrationPref =
+      dependencies.setMigrationPref ?? ((key, value) => setPref(key, value));
+    this.getColumnLabel =
+      dependencies.getColumnLabel ?? ((key) => getString(key as any));
+  }
 
   /**
    * Get column configurations
@@ -41,7 +72,7 @@ export class TableColumnManager {
     const defaultColumns = this.getDefaultColumns();
     this._columns = defaultColumns;
     try {
-      const result = this.largePrefHelper.getValue(
+      const result = this.columnPreferenceStore.getValue(
         "columns",
       ) as PersistedColumnState[];
       if (result.length === this._columns.length) {
@@ -62,8 +93,7 @@ export class TableColumnManager {
     this.migrateTagColumnLayoutIfNeeded();
     this.migrateNameColumnWidthIfNeeded();
     this._columns.map((column) =>
-      // @ts-expect-error ignore getString type check
-      Object.assign(column, { label: getString(column.dataKey) }),
+      Object.assign(column, { label: this.getColumnLabel(column.dataKey) }),
     );
     return this._columns;
   }
@@ -87,7 +117,7 @@ export class TableColumnManager {
         const persistedColumns = this._columns.map((column) =>
           this.toPersistedColumnState(column),
         );
-        this.largePrefHelper.setValue("columns", persistedColumns);
+        this.columnPreferenceStore.setValue("columns", persistedColumns);
       }
     } catch (error) {
       ztoolkit.log(`updateColumns failed: ${error}`);
@@ -203,7 +233,7 @@ export class TableColumnManager {
   }
 
   private migrateTagColumnLayoutIfNeeded(): void {
-    if (getPref(TAG_COLUMN_MIGRATION_PREF)) {
+    if (this.getMigrationPref(TAG_COLUMN_MIGRATION_PREF)) {
       return;
     }
 
@@ -234,11 +264,11 @@ export class TableColumnManager {
     });
 
     this._columns = orderedColumns;
-    this.largePrefHelper.setValue(
+    this.columnPreferenceStore.setValue(
       "columns",
       this._columns.map((column) => this.toPersistedColumnState(column)),
     );
-    setPref(TAG_COLUMN_MIGRATION_PREF, true);
+    this.setMigrationPref(TAG_COLUMN_MIGRATION_PREF, true);
   }
 
   /**
@@ -250,7 +280,7 @@ export class TableColumnManager {
    * nearly unreadable.
    */
   private migrateNameColumnWidthIfNeeded(): void {
-    if (getPref(NAME_COLUMN_MIGRATION_PREF)) {
+    if (this.getMigrationPref(NAME_COLUMN_MIGRATION_PREF)) {
       return;
     }
 
@@ -267,11 +297,11 @@ export class TableColumnManager {
     }
     nameColumn.minWidth = NAME_COLUMN_MIN_WIDTH;
 
-    this.largePrefHelper.setValue(
+    this.columnPreferenceStore.setValue(
       "columns",
       this._columns.map((column) => this.toPersistedColumnState(column)),
     );
-    setPref(NAME_COLUMN_MIGRATION_PREF, true);
+    this.setMigrationPref(NAME_COLUMN_MIGRATION_PREF, true);
   }
 
   /**
@@ -304,8 +334,7 @@ export class TableColumnManager {
         children: allColumnSelectMenus.map((menuItem) => ({
           tag: "menuitem",
           attributes: {
-            // @ts-expect-error ignore getString type check
-            label: getString(menuItem),
+            label: this.getColumnLabel(menuItem),
             value: menuItem,
             checked: !(
               this.columns.find((column) => column.dataKey === menuItem) as any

--- a/src/utils/window.ts
+++ b/src/utils/window.ts
@@ -1,10 +1,20 @@
-export { isWindowAlive };
+export { getActiveWindow, isWindowAlive };
 
 /**
  * Check if the window is alive.
  * Useful to prevent opening duplicate windows.
  * @param win
  */
-function isWindowAlive(win?: Window) {
-  return win && !Components.utils.isDeadWrapper(win) && !win.closed;
+function isWindowAlive(win?: Window | null): win is Window {
+  return !!win && !Components.utils.isDeadWrapper(win) && !win.closed;
+}
+
+/**
+ * Return the currently active Zotero window when it is still usable.
+ * This matters for dependent dialogs, which otherwise fall back to the main
+ * window and can pull it in front of an add-on window on Zotero 10.
+ */
+function getActiveWindow(): Window | undefined {
+  const win = Services.focus.activeWindow as Window | null;
+  return isWindowAlive(win) ? win : undefined;
 }

--- a/src/utils/window.ts
+++ b/src/utils/window.ts
@@ -1,4 +1,4 @@
-export { getActiveWindow, isWindowAlive };
+export { getActiveWindow, isWindowAlive, resolveProgressWindowOwner };
 
 /**
  * Check if the window is alive.
@@ -17,4 +17,21 @@ function isWindowAlive(win?: Window | null): win is Window {
 function getActiveWindow(): Window | undefined {
   const win = Services.focus.activeWindow as Window | null;
   return isWindowAlive(win) ? win : undefined;
+}
+
+/**
+ * Prefer an explicitly supplied owner and otherwise use the active Zotero
+ * window. Keeping this decision in one place makes retries and callers with an
+ * optional owner behave consistently.
+ */
+function resolveProgressWindowOwner(
+  preferred?: Window | null,
+  fallback?: Window | null,
+): Window | undefined {
+  if (isWindowAlive(preferred)) {
+    return preferred;
+  }
+  const fallbackOwner =
+    typeof fallback === "undefined" ? getActiveWindow() : fallback;
+  return isWindowAlive(fallbackOwner) ? fallbackOwner : undefined;
 }

--- a/test/zotero10Compatibility.test.ts
+++ b/test/zotero10Compatibility.test.ts
@@ -1,26 +1,136 @@
 import { assert } from "chai";
-import { TableColumnManager } from "../src/ui/table/TableColumnManager";
-import { getActiveWindow } from "../src/utils/window";
+import {
+  TableColumnManager,
+  type TableColumnManagerDependencies,
+} from "../src/ui/table/TableColumnManager";
+import {
+  getActiveWindow,
+  isWindowAlive,
+  resolveProgressWindowOwner,
+} from "../src/utils/window";
 
-describe("Zotero 10 UI compatibility", function () {
-  it("keeps the add-on name column readable", function () {
-    const nameColumn = new TableColumnManager().columns.find(
-      (column) => column.dataKey === "menu-name",
-    );
+type StoredColumn = {
+  dataKey: string;
+  hidden?: boolean;
+  ordinal?: number;
+  width?: unknown;
+};
 
-    assert.exists(nameColumn);
-    assert.isAtLeast(nameColumn?.width ?? 0, 160);
-    assert.equal(nameColumn?.minWidth, 160);
+function getDefaultStoredColumns(): StoredColumn[] {
+  const manager = new TableColumnManager({
+    columnPreferenceStore: {
+      getValue: () => [],
+      setValue: () => undefined,
+    },
+    getMigrationPref: () => true,
+    setMigrationPref: () => undefined,
+    getColumnLabel: (key) => key,
   });
 
-  it("uses the active Zotero window for dependent dialogs", function () {
+  return manager.columns.map(({ dataKey, hidden, ordinal, width }) => ({
+    dataKey,
+    hidden,
+    ordinal,
+    width,
+  }));
+}
+
+function createColumnMigrationHarness(nameWidth: unknown) {
+  let storedColumns = getDefaultStoredColumns();
+  const storedNameColumn = storedColumns.find(
+    (column) => column.dataKey === "menu-name",
+  )!;
+  if (typeof nameWidth === "undefined") {
+    delete storedNameColumn.width;
+  } else {
+    storedNameColumn.width = nameWidth;
+  }
+
+  const migrationPrefs = new Map([
+    ["tagColumnLayoutMigrated", true],
+    ["nameColumnWidthMigrated", false],
+  ]);
+  let writeCount = 0;
+  const dependencies: TableColumnManagerDependencies = {
+    columnPreferenceStore: {
+      getValue: () => storedColumns,
+      setValue: (_key, value) => {
+        storedColumns = (value as StoredColumn[]).map((column) => ({
+          ...column,
+        }));
+        writeCount += 1;
+      },
+    },
+    getMigrationPref: (key) => migrationPrefs.get(key),
+    setMigrationPref: (key, value) => migrationPrefs.set(key, value),
+    getColumnLabel: (key) => key,
+  };
+
+  return {
+    dependencies,
+    getStoredColumns: () => storedColumns,
+    getWriteCount: () => writeCount,
+    migrationPrefs,
+  };
+}
+
+describe("Zotero 10 UI compatibility", function () {
+  for (const [legacyWidth, expectedWidth, label] of [
+    [undefined, 200, "missing"],
+    ["invalid", 200, "invalid"],
+    [159, 200, "159"],
+    [160, 160, "160"],
+    [240, 240, "240"],
+  ] as const) {
+    it(`migrates the persisted add-on name width ${label}`, function () {
+      const harness = createColumnMigrationHarness(legacyWidth);
+      const manager = new TableColumnManager(harness.dependencies);
+      const nameColumn = manager.columns.find(
+        (column) => column.dataKey === "menu-name",
+      );
+
+      assert.exists(nameColumn);
+      assert.equal(nameColumn?.width, expectedWidth);
+      assert.equal(nameColumn?.minWidth, 160);
+      assert.equal(
+        harness
+          .getStoredColumns()
+          .find((column) => column.dataKey === "menu-name")?.width,
+        expectedWidth,
+      );
+      assert.isTrue(harness.migrationPrefs.get("nameColumnWidthMigrated"));
+      assert.equal(harness.getWriteCount(), 1);
+
+      const secondManager = new TableColumnManager(harness.dependencies);
+      assert.isNotEmpty(secondManager.columns);
+      assert.equal(harness.getWriteCount(), 1, "migration must be idempotent");
+    });
+  }
+
+  it("returns only a live active window for dependent dialogs", function () {
     const activeWindow = Services.focus.activeWindow as Window | null;
-    if (
-      activeWindow &&
-      !Components.utils.isDeadWrapper(activeWindow) &&
-      !activeWindow.closed
-    ) {
-      assert.strictEqual(getActiveWindow(), activeWindow);
-    }
+
+    assert.strictEqual(
+      getActiveWindow(),
+      isWindowAlive(activeWindow) ? activeWindow : undefined,
+    );
+  });
+
+  it("prefers a live owner and falls back from invalid owners", function () {
+    const explicitOwner = { closed: false } as Window;
+    const fallbackOwner = { closed: false } as Window;
+    const closedWindow = { closed: true } as Window;
+
+    assert.isTrue(isWindowAlive(explicitOwner));
+    assert.isTrue(isWindowAlive(fallbackOwner));
+    assert.strictEqual(
+      resolveProgressWindowOwner(explicitOwner, fallbackOwner),
+      explicitOwner,
+    );
+    assert.strictEqual(
+      resolveProgressWindowOwner(closedWindow, fallbackOwner),
+      fallbackOwner,
+    );
+    assert.isUndefined(resolveProgressWindowOwner(closedWindow, null));
   });
 });

--- a/test/zotero10Compatibility.test.ts
+++ b/test/zotero10Compatibility.test.ts
@@ -1,0 +1,26 @@
+import { assert } from "chai";
+import { TableColumnManager } from "../src/ui/table/TableColumnManager";
+import { getActiveWindow } from "../src/utils/window";
+
+describe("Zotero 10 UI compatibility", function () {
+  it("keeps the add-on name column readable", function () {
+    const nameColumn = new TableColumnManager().columns.find(
+      (column) => column.dataKey === "menu-name",
+    );
+
+    assert.exists(nameColumn);
+    assert.isAtLeast(nameColumn?.width ?? 0, 160);
+    assert.equal(nameColumn?.minWidth, 160);
+  });
+
+  it("uses the active Zotero window for dependent dialogs", function () {
+    const activeWindow = Services.focus.activeWindow as Window | null;
+    if (
+      activeWindow &&
+      !Components.utils.isDeadWrapper(activeWindow) &&
+      !activeWindow.closed
+    ) {
+      assert.strictEqual(getActiveWindow(), activeWindow);
+    }
+  });
+});

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -14,6 +14,7 @@ declare namespace _ZoteroTypes {
       'guideStatus': number;
       'firstInstalledVersion': string;
       'tagColumnLayoutMigrated': boolean;
+      'nameColumnWidthMigrated': boolean;
     };
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes two UI regressions that appear in Zotero 10:

1. Installing or updating an add-on can unexpectedly bring Zotero's main window to the foreground, causing the Add-on Market window to lose focus.
2. The add-on name column becomes extremely narrow, making the add-on list difficult to read.

## Root Cause

### Window focus

Zotero changed `ProgressWindow` from an always-on-top window to a dependent window. When no owner window is specified, it falls back to Zotero's main window.

As a result, progress notifications created during add-on installation can bring the main window to the foreground on Windows.

Related Zotero changes:

* https://github.com/zotero/zotero/commit/30b5bf4bb978655c62107e458c36da417c93f6fc
* https://github.com/zotero/zotero/commit/e1759daa001a3f496e4161413ceff25f2a444dbf

### Name column width

The `menu-name` column was configured with `staticWidth: true` but without an explicit width.

Zotero 10 changed the virtualized table width calculation, which exposed this configuration and caused the column to be rendered close to its minimum width.

## Changes

* Use the currently active Add-on Market window as the owner of installation, uninstallation, update, and rollback progress windows.
* Preserve the original owner window when retrying another XPI download source.
* Set the add-on name column width to `200px` with a minimum width of `160px`.
* Add a one-time migration that repairs existing persisted layouts with a missing or excessively narrow name column.
* Add Zotero 10 compatibility tests for the active-window helper and name-column configuration.

## Validation

* Production build completed successfully.
* Source TypeScript checks passed.
* Test TypeScript checks passed.
* ESLint passed for the changed source and test files.
* `git diff --check` passed.

The full Zotero GUI test runner could not be started in the current environment because installing Xvfb requires elevated permissions. Manual verification on Windows with Zotero 10 is recommended, especially for the window-focus behavior.
